### PR TITLE
Refactor common database utils into a module

### DIFF
--- a/sintia/modules/user_stats.py
+++ b/sintia/modules/user_stats.py
@@ -1,46 +1,29 @@
 from datetime import datetime
 
-import aiomysql
 import discord
 
-from sintia.config import get_config_section
-from sintia.util import memoize
-
-
-@memoize
-async def get_connection_pool():
-    qdb_config = get_config_section('user_stats')
-    return await aiomysql.create_pool(
-        host=qdb_config['hostname'],
-        port=qdb_config.getint('post', 3306),
-        user=qdb_config['username'],
-        password=qdb_config['password'],
-        db=qdb_config['database'],
-    )
+from sintia.mysql import query_single_commit, query_single
 
 
 async def record_message(message: discord.Message) -> None:
-    qdb_pool = await get_connection_pool()
-    async with qdb_pool.acquire() as connection:
-        async with connection.cursor(aiomysql.DictCursor) as cursor:
-            await cursor.execute("""
-                INSERT INTO user_activity_history (guild_id, channel_id, user_id, last_spoke_at)
-                VALUES (%s, %s, %s, %s)
-                ON DUPLICATE KEY UPDATE last_spoke_at = %s
-            """, (message.guild.id, message.channel.id, message.author.id, message.created_at, message.created_at))
-
-            await connection.commit()
+    await query_single_commit(
+        """
+        INSERT INTO user_activity_history (guild_id, channel_id, user_id, last_spoke_at)
+        VALUES (%s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE last_spoke_at = %s
+        """,
+        message.guild.id, message.channel.id, message.author.id, message.created_at, message.created_at,
+    )
 
 
 async def get_user_last_spoke(user: discord.User, guild: discord.Guild) -> datetime:
-    qdb_pool = await get_connection_pool()
-    async with qdb_pool.acquire() as connection:
-        async with connection.cursor(aiomysql.DictCursor) as cursor:
-            await cursor.execute("""
-                SELECT MAX(last_spoke_at) AS last_spoke_at
-                FROM user_activity_history
-                WHERE guild_id = %s AND user_id = %s
-            """, (guild.id, user.id))
-            row = await cursor.fetchone()
+    row = await query_single(
+        """
+        SELECT MAX(last_spoke_at) AS last_spoke_at
+        FROM user_activity_history
+        WHERE guild_id = %s AND user_id = %s
+        """,
+        guild.id, user.id,
+    )
 
-            return row['last_spoke_at']
+    return row['last_spoke_at']

--- a/sintia/modules/user_votes.py
+++ b/sintia/modules/user_votes.py
@@ -1,22 +1,8 @@
 from typing import Mapping
 
-import aiomysql
 import discord
 
-from sintia.config import get_config_section
-from sintia.util import memoize
-
-
-@memoize
-async def get_connection_pool():
-    qdb_config = get_config_section('user_votes')
-    return await aiomysql.create_pool(
-        host=qdb_config['hostname'],
-        port=qdb_config.getint('post', 3306),
-        user=qdb_config['username'],
-        password=qdb_config['password'],
-        db=qdb_config['database'],
-    )
+from sintia.mysql import query_single, query_many_commit
 
 
 async def add_votes(message: discord.Message, votes: Mapping[discord.User, int]) -> None:
@@ -26,25 +12,25 @@ async def add_votes(message: discord.Message, votes: Mapping[discord.User, int])
         if score != 0
     ]
 
-    qdb_pool = await get_connection_pool()
-    async with qdb_pool.acquire() as connection:
-        async with connection.cursor(aiomysql.DictCursor) as cursor:
-            await cursor.executemany("""
-                INSERT INTO user_votes (guild_id, message_id, voted_user_id, voting_user_id, points_delta) 
-                VALUES (%s, %s, %s, %s, %s)
-            """, votes)
-
-            await connection.commit()
+    await query_many_commit(
+        """
+        INSERT INTO user_votes (guild_id, message_id, voted_user_id, voting_user_id, points_delta) 
+        VALUES (%s, %s, %s, %s, %s)
+        """,
+        *votes,
+    )
 
 
 async def get_score_for_user(user: discord.User, guild: discord.Guild) -> int:
-    qdb_pool = await get_connection_pool()
-    async with qdb_pool.acquire() as connection:
-        async with connection.cursor(aiomysql.DictCursor) as cursor:
-            await cursor.execute("""
-                SELECT COALESCE(SUM(points_delta), 0) AS score 
-                FROM user_votes 
-                WHERE guild_id = %s AND voted_user_id = %s
-            """, (guild.id, user.id))
-            row = await cursor.fetchone()
-            return row['score']
+    row = await query_single(
+        """
+        SELECT COALESCE(SUM(points_delta), 0) AS score 
+        FROM user_votes 
+        WHERE guild_id = %s AND voted_user_id = %s
+        """,
+        guild.id,
+        user.id,
+    )
+
+    return row['score']
+

--- a/sintia/mysql.py
+++ b/sintia/mysql.py
@@ -1,0 +1,58 @@
+from typing import Type, Optional, TypeVar, List
+
+import aiomysql
+
+from sintia.config import get_config_section
+from sintia.util import memoize
+
+T = TypeVar('T')
+
+
+@memoize
+async def get_connection_pool():
+    qdb_config = get_config_section('mysql')
+    return await aiomysql.create_pool(
+        host=qdb_config['hostname'],
+        port=qdb_config.getint('post', 3306),
+        user=qdb_config['username'],
+        password=qdb_config['password'],
+        db=qdb_config['database'],
+    )
+
+
+async def query_single(query: str, *args, result_type: Type[T] = dict) -> Optional[T]:
+    qdb_pool = await get_connection_pool()
+    async with qdb_pool.acquire() as connection:
+        async with connection.cursor(aiomysql.DictCursor) as cursor:
+            await cursor.execute(query, args)
+
+            row = await cursor.fetchone()
+            if not row:
+                return None
+
+            return result_type(**row)
+
+
+async def query_all(query: str, *args, result_type: Type[T] = dict) -> List[T]:
+    qdb_pool = await get_connection_pool()
+    async with qdb_pool.acquire() as connection:
+        async with connection.cursor(aiomysql.DictCursor) as cursor:
+            await cursor.execute(query, args)
+
+            return [result_type(**row) async for row in cursor]
+
+
+async def query_single_commit(query: str, *args) -> None:
+    qdb_pool = await get_connection_pool()
+    async with qdb_pool.acquire() as connection:
+        async with connection.cursor(aiomysql.DictCursor) as cursor:
+            await cursor.execute(query, args)
+            await connection.commit()
+
+
+async def query_many_commit(query: str, *args) -> None:
+    qdb_pool = await get_connection_pool()
+    async with qdb_pool.acquire() as connection:
+        async with connection.cursor(aiomysql.DictCursor) as cursor:
+            await cursor.executemany(query, args)
+            await connection.commit()


### PR DESCRIPTION
There's a lot of repetitive code in `quotes`, `user_stats` and `user_votes`. This makes maintenance hard.
In addition, additional modules that would want to use the db would require that same kind of copy-pasta job.

This PR refactors all of the functionality into common module with an addition of `result_type` parameter to the read queries and massage results which makes working with the module a lot easier over the long run.