### PR TITLE
Display wikipedia results as a card instead of text

### DIFF
--- a/sintia/sintia.py
+++ b/sintia/sintia.py
@@ -323,7 +323,7 @@ class Sintia(discord.Client):
         raw_search_results = await self.http_get_request('https://en.wikipedia.org/w/api.php', params={
             'action': 'query',
             'format': 'json',
-            'prop': 'extracts|info',
+            'prop': 'extracts|info|pageimages',
             'indexpageids': 1,
             'generator': 'search',
             'utf8': 1,
@@ -332,6 +332,7 @@ class Sintia(discord.Client):
             'inprop': 'url',
             'gsrsearch': argument,
             'gsrlimit': 1,
+            'pithumbsize': 1024,
         })
 
         search_results = json.loads(raw_search_results)
@@ -342,12 +343,17 @@ class Sintia(discord.Client):
         page_id, *rest = page_ids
         page_info = search_results['query']['pages'][page_id]
         paragraphs = page_info['extract'].split('\n')
-        return await message.channel.send(
-            f'**{page_info["title"]}**\n'
-            f'<{page_info["canonicalurl"]}>'
-            f'\n'
-            f'{paragraphs[0]}\n',
+        
+        embed = discord.Embed(
+            title=page_info['title'],
+            description=paragraphs[0],
+            url=page_info['canonicalurl'],
         )
+
+        if 'thumbnail' in page_info:
+            embed.set_thumbnail(url=page_info['thumbnail'].get('source'))
+
+        return await message.channel.send(embed=embed)
 
     @command_handler('ud')
     async def urbandictionary_search(self, message: discord.Message, argument: str) -> None:


### PR DESCRIPTION
It was requested that Sintia show the wikipedia result's images with the result.
After experimentation, it was agreed that using a card embed is the best way to accomplish this.

![Screenshot from 2019-04-25 15-52-46](https://user-images.githubusercontent.com/205628/56773235-2ec36200-6772-11e9-9b04-bd7db6f2ceca.png)
